### PR TITLE
Fix missing Terceros export

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,7 +91,7 @@ function App() {
                   <Route index element={<FacturasPage />} />
                   <Route path="facturas" element={<FacturasPage />} />
                   <Route path="transacciones" element={<Transacciones />} />
-                  <Route path="contratos" element={<ContratosContables />} />
+                  <Route path="contratos" element={<Contratos />} />
                   <Route path="servicios" element={<LineasServicios />} />
                   <Route path="impuestos" element={<Impuestos />} />
                   <Route path="terceros" element={<Terceros />} />

--- a/src/pages/contabilidad/Terceros.jsx
+++ b/src/pages/contabilidad/Terceros.jsx
@@ -1,1 +1,12 @@
- 
+import React from 'react';
+
+const Terceros = () => {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Terceros</h1>
+      <p className="text-muted-foreground">Este módulo está en construcción.</p>
+    </div>
+  );
+};
+
+export default Terceros;


### PR DESCRIPTION
## Summary
- implement `Terceros` component with default export
- use `Contratos` component for contabilidad route

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*